### PR TITLE
Some improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.41.0
+          toolchain: 1.44.0
           override: true
 
       - name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ pbkdf2 = { version = "0.6.0", default-features = false }
 rand = { version = "0.7.3", optional = true }
 sha2 = { version = "0.9.2", default-features = false }
 unicode-normalization = { version = "0.1.16", default-features = false }
+zeroize = "1.2.0"
 
 [dev-dependencies]
 tiny-bip39 = { package = "tiny-bip39", version = "0.8.0" }

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 [crates-url]: https://crates.io/crates/bip0039
 [docs-svg]: https://docs.rs/bip0039/badge.svg
 [docs-url]: https://docs.rs/bip0039
-[msrv-svg]: https://img.shields.io/badge/rustc-1.41+-blue.svg
-[msrv-url]: https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html
+[msrv-svg]: https://img.shields.io/badge/rustc-1.44+-blue.svg
+[msrv-url]: https://blog.rust-lang.org/2020/06/04/Rust-1.44.0.html
 [codecov-svg]: https://img.shields.io/codecov/c/github/koushiro/bip0039-rs
 [codecov-url]: https://codecov.io/gh/koushiro/bip0039-rs
 [deps-svg]: https://deps.rs/repo/github/koushiro/bip0039-rs/status.svg

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -16,17 +16,18 @@ fn bench_generate(c: &mut Criterion) {
 }
 
 fn bench_from_entropy(c: &mut Criterion) {
+    let entropy = [
+        0x1a, 0x48, 0x6a, 0x5f, 0xbe, 0x53, 0x63, 0x99, 0x84, 0xcb, 0x64, 0xb0, 0x70, 0x75, 0x5f,
+        0x7b,
+    ];
     c.bench_function("tiny-bip39::from_entropy", |b| {
         use tiny_bip39::{Language, Mnemonic};
-        let entropy = hex::decode("1a486a5fbe53639984cb64b070755f7b").unwrap();
         b.iter(|| {
             let _mnemonic = black_box(Mnemonic::from_entropy(&entropy, Language::English));
         })
     });
     c.bench_function("bip0039::from_entropy", |b| {
         use bip0039::{Language, Mnemonic};
-        let entropy = hex::decode("1a486a5fbe53639984cb64b070755f7b").unwrap();
-        let entropy = entropy.as_slice();
         b.iter(|| {
             let _mnemonic = black_box(Mnemonic::from_entropy_in(Language::English, entropy));
         })
@@ -34,16 +35,15 @@ fn bench_from_entropy(c: &mut Criterion) {
 }
 
 fn bench_from_phrase(c: &mut Criterion) {
+    let phrase = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
     c.bench_function("tiny-bip39::from_phrase", |b| {
         use tiny_bip39::{Language, Mnemonic};
-        let phrase = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
         b.iter(|| {
             let _mnemonic = black_box(Mnemonic::from_phrase(phrase, Language::English));
         })
     });
     c.bench_function("bip0039::from_phrase", |b| {
         use bip0039::{Language, Mnemonic};
-        let phrase = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
         b.iter(|| {
             let _mnemonic = black_box(Mnemonic::from_phrase_in(Language::English, phrase));
         })

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -273,4 +273,18 @@ mod tests {
             assert_eq!(is_sorted(lang.word_list()), lang.is_sorted());
         }
     }
+
+    #[cfg(feature = "all-languages")]
+    #[test]
+    fn word_list_is_normalized() {
+        for lang in Language::all() {
+            for &word in lang.word_list() {
+                assert!(
+                    unicode_normalization::is_nfkd(word),
+                    "word '{}' is not normalized",
+                    word
+                )
+            }
+        }
+    }
 }

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -461,7 +461,7 @@ impl Mnemonic {
         const PBKDF2_ROUNDS: u32 = 2048;
         const PBKDF2_BYTES: usize = 64;
 
-        // the phrase must be normalized
+        // the phrase has been normalized
         let normalized_password = self.phrase();
         let normalized_salt = {
             let mut salt = Cow::Owned(format!("mnemonic{}", passphrase.as_ref()));


### PR DESCRIPTION
* Use `Cow` to avoid allocation for normalization when there are no special UTF8 characters in the string.
* Zeroize memory of mnemonic when drop
* Bump the MSRV to 1.44+ (required by `zeroize`)