### PR TITLE
Sanitize mnemonic phrase for extra whitespace

### DIFF
--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -349,7 +349,7 @@ impl Mnemonic {
         let entropy = Self::phrase_to_entropy(lang, phrase.as_ref())?;
         Ok(Mnemonic {
             lang,
-            phrase: phrase.into_owned(),
+            phrase: phrase.split_whitespace().collect::<Vec<&str>>().join(" "),
             entropy,
         })
     }


### PR DESCRIPTION
If a phrase with extra whitespace gets passed to the Mnemonic::from_phrase method, the word verification and entropy generation happens correctly but the phrase is saved as is with the extra whitespace.

Added a line to cleanup the whitespace before the phrase is saved.