### PR TITLE
Add `coins-bip39` benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ See documentation and examples at https://docs.rs/bip0039.
 
 - [bip39](https://github.com/rust-bitcoin/rust-bip39)
 - [tiny-bip39](https://github.com/maciejhirsz/tiny-bip39)
+- [coins-bip39](https://github.com/summa-tx/bitcoins-rs/tree/main/bip39)
 
 ## License
 

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -7,8 +7,10 @@ resolver = "2"
 
 [dev-dependencies]
 bip0039 = { path = ".." }
-bip39 = { package = "tiny-bip39", version = "0.8" }
-criterion = "0.3"
+bip39 = { package = "tiny-bip39", version = "1.0" }
+coins-bip39 = "0.7" 
+criterion = "0.4"
+rand = "0.8"
 
 [[bench]]
 name = "bench"

--- a/benchmark/bench.rs
+++ b/benchmark/bench.rs
@@ -4,13 +4,25 @@ fn bench_generate(c: &mut Criterion) {
     c.bench_function("tiny-bip39::generate", |b| {
         use bip39::{Language, Mnemonic, MnemonicType};
         b.iter(|| {
-            let _mnemonic = black_box(Mnemonic::new(MnemonicType::Words12, Language::English));
+            let mnemonic = black_box(Mnemonic::new(MnemonicType::Words12, Language::English));
+            let _phrase = mnemonic.phrase();
+        })
+    });
+    c.bench_function("coins-bip39::new_with_count", |b| {
+        use coins_bip39::{English, Mnemonic};
+        b.iter(|| {
+            let _mnemonic = black_box({
+                let mut rng = rand::thread_rng();
+                let mnemonic = <Mnemonic<English>>::new_with_count(&mut rng, 12).unwrap();
+                let _phrase = mnemonic.to_phrase();
+            });
         })
     });
     c.bench_function("bip0039::generate", |b| {
         use bip0039::{Count, Language, Mnemonic};
         b.iter(|| {
-            let _mnemonic = black_box(Mnemonic::generate_in(Language::English, Count::Words12));
+            let mnemonic = black_box(Mnemonic::generate_in(Language::English, Count::Words12));
+            let _phrase = mnemonic.phrase();
         })
     });
 }
@@ -42,6 +54,12 @@ fn bench_from_phrase(c: &mut Criterion) {
             let _mnemonic = black_box(Mnemonic::from_phrase(phrase, Language::English));
         })
     });
+    c.bench_function("coins-bip39::new_from_phrase", |b| {
+        use coins_bip39::{English, Mnemonic};
+        b.iter(|| {
+            let _mnemonic = black_box(<Mnemonic<English>>::new_from_phrase(phrase).unwrap());
+        })
+    });
     c.bench_function("bip0039::from_phrase", |b| {
         use bip0039::{Language, Mnemonic};
         b.iter(|| {
@@ -56,6 +74,14 @@ fn bench_to_seed(c: &mut Criterion) {
         let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
         b.iter(|| {
             let _seed = black_box(Seed::new(&mnemonic, ""));
+        })
+    });
+    c.bench_function("coins-bip39::to_seed", |b| {
+        use coins_bip39::{English, Mnemonic};
+        let mut rng = rand::thread_rng();
+        let mnemonic = <Mnemonic<English>>::new_with_count(&mut rng, 12).unwrap();
+        b.iter(|| {
+            let _key = black_box(mnemonic.master_key(None).unwrap()); // calling `to_seed`
         })
     });
     c.bench_function("bip0039::to_seed", |b| {


### PR DESCRIPTION
benchmark results:

- generate mnemonic randomly:
```
tiny-bip39::generate    time:   [208.94 ns 208.99 ns 209.04 ns]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

coins-bip39::new_with_count
                        time:   [23.876 µs 23.884 µs 23.892 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

bip0039::generate       time:   [675.79 ns 677.00 ns 678.02 ns]
Found 24 outliers among 100 measurements (24.00%)
  16 (16.00%) high mild
  8 (8.00%) high severe
```

- generate mnemonic from phrase:

```
tiny-bip39::from_phrase time:   [1.1283 µs 1.1368 µs 1.1469 µs]
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

coins-bip39::new_from_phrase
                        time:   [299.78 µs 300.21 µs 300.68 µs]

bip0039::from_phrase    time:   [1.0475 µs 1.0543 µs 1.0617 µs]
Found 28 outliers among 100 measurements (28.00%)
  13 (13.00%) low mild
  14 (14.00%) high mild
  1 (1.00%) high severe
```

- generate seed from phrase and password:

```
tiny-bip39::to_seed     time:   [797.17 µs 802.41 µs 806.61 µs]

coins-bip39::to_seed    time:   [862.56 µs 863.83 µs 865.11 µs]
Found 16 outliers among 100 measurements (16.00%)
  10 (10.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

bip0039::to_seed        time:   [799.82 µs 800.54 µs 801.25 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```