### PR TITLE
Use generic type for language of mnemonic instead of parameter

### DIFF
--- a/benchmark/bip0039.rs
+++ b/benchmark/bip0039.rs
@@ -21,10 +21,10 @@ fn bench_generate(c: &mut Criterion) {
         })
     });
     c.bench_function("bip0039::generate", |b| {
-        use bip0039::{Count, Language, Mnemonic};
+        use bip0039::{Count, Mnemonic};
         b.iter(|| {
             let _phrase = black_box({
-                let mnemonic = Mnemonic::generate_in(Language::English, Count::Words12);
+                let mnemonic = <Mnemonic>::generate(Count::Words12);
                 mnemonic.phrase().to_string()
             });
         })
@@ -43,9 +43,9 @@ fn bench_from_entropy(c: &mut Criterion) {
         })
     });
     c.bench_function("bip0039::from_entropy", |b| {
-        use bip0039::{Language, Mnemonic};
+        use bip0039::Mnemonic;
         b.iter(|| {
-            let _mnemonic = black_box(Mnemonic::from_entropy_in(Language::English, entropy));
+            let _mnemonic = black_box(<Mnemonic>::from_entropy(entropy));
         })
     });
 }
@@ -65,9 +65,9 @@ fn bench_from_phrase(c: &mut Criterion) {
         })
     });
     c.bench_function("bip0039::from_phrase", |b| {
-        use bip0039::{Language, Mnemonic};
+        use bip0039::Mnemonic;
         b.iter(|| {
-            let _mnemonic = black_box(Mnemonic::from_phrase_in(Language::English, phrase));
+            let _mnemonic = black_box(<Mnemonic>::from_phrase(phrase));
         })
     });
 }
@@ -89,8 +89,8 @@ fn bench_to_seed(c: &mut Criterion) {
         })
     });
     c.bench_function("bip0039::to_seed", |b| {
-        use bip0039::{Count, Language, Mnemonic};
-        let mnemonic = Mnemonic::generate_in(Language::English, Count::Words12);
+        use bip0039::{Count, Mnemonic};
+        let mnemonic = <Mnemonic>::generate(Count::Words12);
         b.iter(|| {
             let _seed = black_box(mnemonic.to_seed(""));
         })

--- a/bip0039/Cargo.toml
+++ b/bip0039/Cargo.toml
@@ -13,11 +13,7 @@ documentation = "https://docs.rs/bip0039"
 repository = "https://github.com/koushiro/bip0039"
 keywords = ["bip39", "bitcoin", "crypto", "mnemonic"]
 categories = ["cryptography"]
-exclude = [
-    ".github",
-    "words",
-    "benchmark",
-]
+exclude = ["words"]
 
 [features]
 default = ["std", "rand"]

--- a/bip0039/src/language/mod.rs
+++ b/bip0039/src/language/mod.rs
@@ -22,7 +22,7 @@ mod spanish;
 ///
 /// The English language is always available, other languages are enabled using
 /// the compilation features.
-pub trait Lang: Sized {
+pub trait Language: Sized {
     /// The word list for this language.
     const WORD_LIST: &'static [&'static str];
 
@@ -78,7 +78,7 @@ pub trait Lang: Sized {
 /// other languages are enabled using the compilation features.
 #[derive(Copy, Clone, Debug)]
 pub struct English;
-impl Lang for English {
+impl Language for English {
     const WORD_LIST: &'static [&'static str] = &english::WORDS;
 
     fn is_sorted() -> bool {
@@ -91,7 +91,7 @@ impl Lang for English {
 #[derive(Copy, Clone, Debug)]
 pub struct ChineseSimplified;
 #[cfg(feature = "chinese-simplified")]
-impl Lang for ChineseSimplified {
+impl Language for ChineseSimplified {
     const WORD_LIST: &'static [&'static str] = &chinese_simplified::WORDS;
 }
 
@@ -100,7 +100,7 @@ impl Lang for ChineseSimplified {
 #[derive(Copy, Clone, Debug)]
 pub struct ChineseTraditional;
 #[cfg(feature = "chinese-traditional")]
-impl Lang for ChineseTraditional {
+impl Language for ChineseTraditional {
     const WORD_LIST: &'static [&'static str] = &chinese_traditional::WORDS;
 }
 
@@ -109,7 +109,7 @@ impl Lang for ChineseTraditional {
 #[derive(Copy, Clone, Debug)]
 pub struct Czech;
 #[cfg(feature = "czech")]
-impl Lang for Czech {
+impl Language for Czech {
     const WORD_LIST: &'static [&'static str] = &czech::WORDS;
 }
 
@@ -118,7 +118,7 @@ impl Lang for Czech {
 #[derive(Copy, Clone, Debug)]
 pub struct French;
 #[cfg(feature = "french")]
-impl Lang for French {
+impl Language for French {
     const WORD_LIST: &'static [&'static str] = &french::WORDS;
 }
 
@@ -127,7 +127,7 @@ impl Lang for French {
 #[derive(Copy, Clone, Debug)]
 pub struct Italian;
 #[cfg(feature = "italian")]
-impl Lang for Italian {
+impl Language for Italian {
     const WORD_LIST: &'static [&'static str] = &italian::WORDS;
 
     fn is_sorted() -> bool {
@@ -140,7 +140,7 @@ impl Lang for Italian {
 #[derive(Copy, Clone, Debug)]
 pub struct Japanese;
 #[cfg(feature = "japanese")]
-impl Lang for Japanese {
+impl Language for Japanese {
     const WORD_LIST: &'static [&'static str] = &japanese::WORDS;
 }
 
@@ -149,7 +149,7 @@ impl Lang for Japanese {
 #[derive(Copy, Clone, Debug)]
 pub struct Korean;
 #[cfg(feature = "korean")]
-impl Lang for Korean {
+impl Language for Korean {
     const WORD_LIST: &'static [&'static str] = &korean::WORDS;
 
     fn is_sorted() -> bool {
@@ -162,7 +162,7 @@ impl Lang for Korean {
 #[derive(Copy, Clone, Debug)]
 pub struct Portuguese;
 #[cfg(feature = "portuguese")]
-impl Lang for Portuguese {
+impl Language for Portuguese {
     const WORD_LIST: &'static [&'static str] = &portuguese::WORDS;
 
     fn is_sorted() -> bool {
@@ -175,7 +175,7 @@ impl Lang for Portuguese {
 #[derive(Copy, Clone, Debug)]
 pub struct Spanish;
 #[cfg(feature = "spanish")]
-impl Lang for Spanish {
+impl Language for Spanish {
     const WORD_LIST: &'static [&'static str] = &spanish::WORDS;
 }
 
@@ -229,7 +229,7 @@ mod tests {
     #[test]
     fn word_list_is_sorted() {
         use std::cmp::Ordering;
-        fn is_sorted<L: Lang>() -> bool {
+        fn is_sorted<L: Language>() -> bool {
             L::WORD_LIST.windows(2).all(|w| {
                 w[0].partial_cmp(w[1])
                     .map(|o| o != Ordering::Greater)
@@ -258,7 +258,7 @@ mod tests {
     #[cfg(feature = "all-languages")]
     #[test]
     fn word_list_is_normalized() {
-        fn check_normalized<L: Lang>() {
+        fn check_normalized<L: Language>() {
             for &word in L::WORD_LIST {
                 assert!(
                     unicode_normalization::is_nfkd(word),

--- a/bip0039/src/lib.rs
+++ b/bip0039/src/lib.rs
@@ -3,10 +3,10 @@
 //! ## Usage
 //!
 //! ```rust
-//! use bip0039::{Count, Language, Mnemonic};
+//! use bip0039::{Count, Mnemonic, ChineseSimplified};
 //!
 //! /// Generates an English mnemonic with 12 words randomly
-//! let mnemonic = Mnemonic::generate(Count::Words12);
+//! let mnemonic = <Mnemonic>::generate(Count::Words12);
 //!
 //! /// Gets the phrase
 //! let phrase = mnemonic.phrase();
@@ -17,7 +17,7 @@
 //! println!("seed: {}", hex::encode(&seed[..]));
 //!
 //! /// Generates a Simplified Chinese mnemonic with 12 words randomly
-//! let mnemonic = Mnemonic::generate_in(Language::SimplifiedChinese, Count::Words12);
+//! let mnemonic = <Mnemonic<ChineseSimplified>>::generate(Count::Words12);
 //! println!("phrase: {}", mnemonic.phrase());
 //! ```
 //!
@@ -30,11 +30,31 @@
 extern crate alloc;
 
 mod error;
-mod language;
+/// Supported languages for BIP-0039.
+pub mod language;
 mod mnemonic;
 
 pub use self::{
     error::Error,
-    language::Language,
+    language::{English, Lang},
     mnemonic::{Count, Mnemonic},
 };
+
+#[cfg(feature = "chinese-simplified")]
+pub use self::language::ChineseSimplified;
+#[cfg(feature = "chinese-traditional")]
+pub use self::language::ChineseTraditional;
+#[cfg(feature = "czech")]
+pub use self::language::Czech;
+#[cfg(feature = "french")]
+pub use self::language::French;
+#[cfg(feature = "italian")]
+pub use self::language::Italian;
+#[cfg(feature = "japanese")]
+pub use self::language::Japanese;
+#[cfg(feature = "korean")]
+pub use self::language::Korean;
+#[cfg(feature = "portuguese")]
+pub use self::language::Portuguese;
+#[cfg(feature = "spanish")]
+pub use self::language::Spanish;

--- a/bip0039/src/lib.rs
+++ b/bip0039/src/lib.rs
@@ -36,7 +36,7 @@ mod mnemonic;
 
 pub use self::{
     error::Error,
-    language::{English, Lang},
+    language::{English, Language},
     mnemonic::{Count, Mnemonic},
 };
 

--- a/bip0039/src/mnemonic.rs
+++ b/bip0039/src/mnemonic.rs
@@ -16,7 +16,7 @@ use zeroize::Zeroize;
 
 use crate::{
     error::Error,
-    language::{English, Lang},
+    language::{English, Language},
 };
 
 const BITS_PER_WORD: usize = 11;
@@ -177,19 +177,19 @@ pub struct Mnemonic<L = English> {
     entropy: Vec<u8>,
 }
 
-impl<L: Lang> fmt::Debug for Mnemonic<L> {
+impl<L: Language> fmt::Debug for Mnemonic<L> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.phrase())
     }
 }
 
-impl<L: Lang> fmt::Display for Mnemonic<L> {
+impl<L: Language> fmt::Display for Mnemonic<L> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.phrase())
     }
 }
 
-impl<L: Lang> str::FromStr for Mnemonic<L> {
+impl<L: Language> str::FromStr for Mnemonic<L> {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -197,7 +197,7 @@ impl<L: Lang> str::FromStr for Mnemonic<L> {
     }
 }
 
-impl<L: Lang> AsRef<str> for Mnemonic<L> {
+impl<L: Language> AsRef<str> for Mnemonic<L> {
     fn as_ref(&self) -> &str {
         self.phrase()
     }
@@ -216,7 +216,7 @@ impl<L> Drop for Mnemonic<L> {
     }
 }
 
-impl<L: Lang> Mnemonic<L> {
+impl<L: Language> Mnemonic<L> {
     /// Generates a new [`Mnemonic`] randomly in the specified language and word count.
     ///
     /// # Example

--- a/bip0039/tests/generate.rs
+++ b/bip0039/tests/generate.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "rand")]
 #[test]
 fn test_generate() {
-    use bip0039::{language, Count, Lang, Mnemonic};
+    use bip0039::{language, Count, Language, Mnemonic};
 
-    fn generate<L: Lang>(expected_word_count: Count) {
+    fn generate<L: Language>(expected_word_count: Count) {
         let mnemonic = <Mnemonic<L>>::generate(expected_word_count);
         let actual_word_count = mnemonic.phrase().split_whitespace().count();
         assert_eq!(actual_word_count, expected_word_count.word_count());

--- a/bip0039/tests/generate.rs
+++ b/bip0039/tests/generate.rs
@@ -1,21 +1,42 @@
-use bip0039::{Count, Language, Mnemonic};
-
-#[cfg(feature = "rand")]
-fn generate(language: Language, expected_word_count: Count) {
-    let mnemonic = Mnemonic::generate_in(language, expected_word_count);
-    let actual_word_count = mnemonic.phrase().split_whitespace().count();
-    assert_eq!(actual_word_count, expected_word_count.word_count());
-    assert_eq!(mnemonic.to_seed("").len(), 64);
-}
-
 #[cfg(feature = "rand")]
 #[test]
 fn test_generate() {
-    for language in Language::all().iter().cloned() {
-        generate(language, Count::Words12);
-        generate(language, Count::Words15);
-        generate(language, Count::Words18);
-        generate(language, Count::Words21);
-        generate(language, Count::Words24);
+    use bip0039::{language, Count, Lang, Mnemonic};
+
+    fn generate<L: Lang>(expected_word_count: Count) {
+        let mnemonic = <Mnemonic<L>>::generate(expected_word_count);
+        let actual_word_count = mnemonic.phrase().split_whitespace().count();
+        assert_eq!(actual_word_count, expected_word_count.word_count());
+        assert_eq!(mnemonic.to_seed("").len(), 64);
     }
+
+    macro_rules! generate_tests {
+        ($lang:path) => {{
+            generate::<$lang>(Count::Words12);
+            generate::<$lang>(Count::Words15);
+            generate::<$lang>(Count::Words18);
+            generate::<$lang>(Count::Words21);
+            generate::<$lang>(Count::Words24);
+        }};
+    }
+
+    #[cfg(feature = "chinese-simplified")]
+    generate_tests!(language::ChineseSimplified);
+    #[cfg(feature = "chinese-traditional")]
+    generate_tests!(language::ChineseTraditional);
+    #[cfg(feature = "czech")]
+    generate_tests!(language::Czech);
+    generate_tests!(language::English);
+    #[cfg(feature = "french")]
+    generate_tests!(language::French);
+    #[cfg(feature = "italian")]
+    generate_tests!(language::Italian);
+    #[cfg(feature = "japanese")]
+    generate_tests!(language::Japanese);
+    #[cfg(feature = "korean")]
+    generate_tests!(language::Korean);
+    #[cfg(feature = "portuguese")]
+    generate_tests!(language::Portuguese);
+    #[cfg(feature = "spanish")]
+    generate_tests!(language::Spanish);
 }

--- a/bip0039/tests/vectors.rs
+++ b/bip0039/tests/vectors.rs
@@ -1,4 +1,4 @@
-use bip0039::{English, Lang, Mnemonic};
+use bip0039::{English, Language, Mnemonic};
 use serde::Deserialize;
 use unicode_normalization::UnicodeNormalization;
 
@@ -49,7 +49,7 @@ fn test_all_vectors() {
     }
 }
 
-fn test_mnemonic<L: Lang>(
+fn test_mnemonic<L: Language>(
     passphrase: &str,
     entropy_hex: &str,
     expected_phrase: &str,


### PR DESCRIPTION
- Add generic type for `Mnemonic` structure
- Add `Language` trait and remove `Language` enum
- Add following languages that implement `Language` trait:
  - `ChineseSimplified`
  - `ChineseTraditional`
  - `Czech`
  - `English`
  - `French`
  - `Itailian`
  - `Japanese`
  - `Korean`
  - `Portuguese`
  - `Spanish`
- Remove following methods of `Mnemonic`:
  - `generate_in`
  - `from_entropy_in`
  - `from_phrase_in`
  - `validate_in`
- Use `English` language by default for `Mnemonic`