### PR TITLE
chore(bip0039): fix clippy warings when using rustc 1.98

### DIFF
--- a/bip0039/src/mnemonic/mod.rs
+++ b/bip0039/src/mnemonic/mod.rs
@@ -818,9 +818,7 @@ mod tests {
 
         impl zeroize::Zeroize for DropCheckVec {
             fn zeroize(&mut self) {
-                for byte in &mut self.0 {
-                    *byte = 0;
-                }
+                self.0.fill(0);
             }
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI usage statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
